### PR TITLE
[WIP] Fixing git-utils to fix git project crash

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,6 @@
     "fs-plus": "2.9.2",
     "fstream": "0.1.24",
     "fuzzaldrin": "^2.1",
-    "git-utils": "4.1.2",
     "glob": "^7.1.1",
     "grim": "1.5.0",
     "jasmine-json": "~0.0",


### PR DESCRIPTION
### Description of the Change

The git-utils package appears to be what is breaking  atom when attempting to open a git project. Removing it and building clean appears to fix the issue (at least for now)

### Benefits

Atom doesn't instantly break when a git project is open. Can edit/save files, tree-view and git-diff packages also appear to work without glaring side effects 

### Possible Drawbacks

Don't know what side effects removing the package has on atom's core or other packages.

### What needs to be done to remove WIP tag

1. Diagnosing what side effects (if any) exist from removing the package
2. Find a fix for git-utils so that it can be integrated back in

### Applicable Issues

refs #6 